### PR TITLE
gitignore: Ignore .vscode workspace state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 build/
 .gradle/
 coverage/
+.vscode/


### PR DESCRIPTION
VS Code wants to place a .vscode project settings directory inside the working copy. This eliminates that from showing up git status etc.