### PR TITLE
cpp: CMake refactor

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,5 +6,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+enable_testing()
 add_subdirectory(src)
 add_subdirectory(test)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,6 +6,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-enable_testing()
+include(CTest)
 add_subdirectory(src)
 add_subdirectory(test)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(kata)
+project(kata LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,9 +1,10 @@
-add_library(Catch INTERFACE)
-target_include_directories(Catch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/catch/include)
+set(CATCH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/catch/include)
+add_library(Catch2::Catch INTERFACE IMPORTED)
+target_include_directories(Catch2::Catch INTERFACE "${CATCH_INCLUDE_DIR}")
 
 add_executable(CodeKataTest CatchMain.cpp CodeKataTest.cpp)
 target_include_directories(CodeKataTest PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_include_directories(CodeKataTest PRIVATE $<TARGET_PROPERTY:CodeKata,INCLUDE_DIRECTORIES>)
 target_link_libraries(CodeKataTest PRIVATE CodeKata)
-target_link_libraries(CodeKataTest PRIVATE Catch)
+target_link_libraries(CodeKataTest PRIVATE Catch2::Catch)
 add_test(NAME CodeKataTest COMMAND CodeKataTest)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-enable_testing()
 add_library(Catch INTERFACE)
 target_include_directories(Catch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/catch/include)
 


### PR DESCRIPTION
This is a clean up of the CMake scripts in the C++ example project.

- Move testing init to the root CMakeLists to provide global `test` target (as a result also improves IDE integration, helps VS Code CMake Test explorer extension to properly detect the testing targets)
- Use `include(CTest)` instead of `enable_testing`, from browsing various open source projects this seems to be the preferred way of enabling the CTest integration.
- Rename Catch2 library handle to `Catch2::Catch`, which matches upstream examples
- Explicitly state `CXX` as language in the project.